### PR TITLE
Updating to docker 1.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-BOOT2DOCKER_VERSION := 1.9.0
+BOOT2DOCKER_VERSION := 1.9.1
 
 B2D_ISO_FILE := boot2docker.iso
 B2D_ISO_URL := https://github.com/boot2docker/boot2docker/releases/download/v$(BOOT2DOCKER_VERSION)/boot2docker.iso
-B2D_ISO_CHECKSUM := ad49cdb394754148f096cc2c9f22970b
+B2D_ISO_CHECKSUM := 669e0c5f2698188f0d48a2ed2a3e5218
 
 all: parallels virtualbox
 

--- a/tests/parallels/boot2docker_vagrant_parallels.bats
+++ b/tests/parallels/boot2docker_vagrant_parallels.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-DOCKER_TARGET_VERSION=1.9.0
+DOCKER_TARGET_VERSION=1.9.1
 
 # Assume that Vagrantfile exists and basebox is added
 @test "vagrant up" {

--- a/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
+++ b/tests/virtualbox/boot2docker_vagrant_virtualbox.bats
@@ -28,7 +28,7 @@
 	vagrant ssh -c 'docker ps'
 }
 
-DOCKER_TARGET_VERSION=1.9.0
+DOCKER_TARGET_VERSION=1.9.1
 @test "Docker is version DOCKER_TARGET_VERSION=${DOCKER_TARGET_VERSION}" {
 	DOCKER_VERSION=$(vagrant ssh -c "docker version --format '{{.Server.Version}}'" -- -n -T)
 	[ "${DOCKER_VERSION}" == "${DOCKER_TARGET_VERSION}" ]


### PR DESCRIPTION
Updating the URL and checksum for the new boot2docker image and adjusting the test variables to test for the new docker version.

Somehow two tests of the suite don't work for me: "not ok 9 Default synced folder is shared via prl_fs" and "not ok 12 Default synced folder is shared via NFS if B2D_NFS_SYNC is set" but they didn't work before my update either. Should they work, or do I have to prepare anything for them?